### PR TITLE
Preserve reference/quotation attributes when pressing Enter

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -11,7 +11,8 @@
         "aceRegisterBlockElements": "ep_reference/static/js/index",
         "aceEditorCSS":"ep_reference/static/js/index",
         "aceCreateDomLine":"ep_reference/static/js/index",
-        "aceGetFilterStack":"ep_reference/static/js/index"
+        "aceGetFilterStack":"ep_reference/static/js/index",
+        "aceRegisterLineAttributes":"ep_reference/static/js/index"
       },
       "hooks": {
         "eejsBlock_body":"ep_reference/eejs",

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -8,6 +8,7 @@ let originalRight = 0;
 exports.aceEditorCSS = () => ['ep_reference/static/css/editor.css'];
 
 exports.aceRegisterBlockElements = () => ['reference', 'quotation'];
+exports.aceRegisterLineAttributes = () => ['reference', 'quotation'];
 
 exports.handleClientMessage_CUSTOM = (hook, context, cb) => {
   if (context.payload) {


### PR DESCRIPTION
## Summary

Registers `reference` and `quotation` as line attributes via the new `aceRegisterLineAttributes` hook (ether/etherpad-lite#7509), so formatting is preserved when pressing Enter to split a line.

Backwards compatible — the hook is ignored on Etherpad versions without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)