### PR TITLE
refactor: adopt template helper for 1 simple eejsBlock_* hook(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {template} = require('ep_plugin_helpers');
+
 const eejs = require('ep_etherpad-lite/node/eejs/');
 const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
 
@@ -19,10 +21,8 @@ exports.clientVars = referenceToggle.clientVars;
 exports.eejsBlock_mySettings = referenceToggle.eejsBlock_mySettings;
 exports.eejsBlock_padSettings = referenceToggle.eejsBlock_padSettings;
 
-exports.eejsBlock_body = (hookName, args, cb) => {
-  args.content += eejs.require('ep_reference/templates/reference.ejs');
-  cb();
-};
+exports.eejsBlock_body =
+    template('ep_reference/templates/reference.ejs');
 
 exports.eejsBlock_dd_help = (hookName, args, cb) => {
   cb();


### PR DESCRIPTION
## Summary

Adopts the `template()` helper from `ep_plugin_helpers` for 1 `eejsBlock_*` hook(s) that match the strict-simple shape:

```js
exports.eejsBlock_X = (hookName, args, cb) => {
  args.content += eejs.require('plugin/template.ejs');
  cb();
};
```

Replaced with:

```js
exports.eejsBlock_X = template('plugin/template.ejs');
```

Same runtime behavior — eejs renders the same template into the same section. The helper just removes per-plugin re-implementation of the `args.content += eejs.require(...)` boilerplate.

## Out of scope

Hooks with vars, conditional skip logic, or non-eejs content (e.g. raw `<script>` tags being concatenated) are left alone — those need either the helper's `vars`/`skip` callbacks or different helper variants. Part of Phase 4 of the modernization campaign (pilot: ether/ep_align#182, ether/ep_themes#103).