### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const {template} = require('ep_plugin_helpers');
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
 
 // Parallel User Settings + Pad Wide Settings checkboxes for the reference

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ep_reference",
   "description": "Reference content from other Pads",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "author": "johnyma22 (John McLear) <john@mclear.co.uk>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")`

The trailing-slash form breaks under Node's strict ESM exports map resolution. This change is **backward-compatible** with the current CJS etherpad release.